### PR TITLE
Replace type 'null' with 'any' in ContextValue type

### DIFF
--- a/src/models/index.tsx
+++ b/src/models/index.tsx
@@ -17,4 +17,4 @@ export interface Card {
 
 export type State = Array<Column>;
 
-export type ContextValue = {state: State; dispatch: React.Dispatch<Action>} | null;
+export type ContextValue = {state: State; dispatch: React.Dispatch<Action>} | any;


### PR DESCRIPTION
now destrucuring is possible when using the useContext hook, e.g.

```js
const { state, dispatch } = useContext(BoardContext);
```