### PR TITLE
Fix moving cards bug

### DIFF
--- a/src/components/Board.tsx
+++ b/src/components/Board.tsx
@@ -35,10 +35,15 @@ export default function Board() {
       return;
     }
 
+    const start = istate.columns[source.droppableId];
+    const finish = istate.columns[destination.droppableId];
+
     //if these are true the user dropped the card back in the original position
+    //check that it's not the same position in a different column
     if (
       destination.droppable === source.droppable &&
-      destination.index === source.index
+      destination.index === source.index &&
+      start.id === finish.id
     ) {
       return;
     }
@@ -59,9 +64,6 @@ export default function Board() {
     }
 
     //reorder task-id array
-    const start = istate.columns[source.droppableId];
-    const finish = istate.columns[destination.droppableId];
-
     //if a task is moving in same column (moving a card)
     if (start === finish) {
       const newTaskIds = Array.from(start.taskIds);


### PR DESCRIPTION
- Check to make sure the tasks are moving between columns so that if they are moved to the same index in a different column it will recognize the move and update.
- Previously moving to the same index in a different column didn't work because I was just checking for index changes. If two indices were the same it returned immediately because in the same column that means the user put the card back in the same place.
- Now check for same indices AND the column id. If the column id is different the user has moved it to the same position in a different column and the update procedure needs to proceed so don't exit. 
- @mr-robak found the pattern for the failure that let me hone in on this issue immediately. Saved so much time! Excellent testing!!!!