### PR TITLE
Column title is now updated in store and persisted

### DIFF
--- a/src/components/Column.tsx
+++ b/src/components/Column.tsx
@@ -5,7 +5,6 @@ import { makeStyles } from "@material-ui/core/styles";
 import TextField from "@material-ui/core/TextField";
 import Grid from "@material-ui/core/Grid";
 import Paper from "@material-ui/core/Paper";
-//experiment
 import BoardContext from "../state/BoardContext";
 import { IconButton, Menu, MenuItem, Tooltip } from "@material-ui/core";
 import MoreHorizOutlinedIcon from "@material-ui/icons/MoreHorizOutlined";
@@ -74,6 +73,10 @@ export default function Column(props: PropItem) {
   function setToNotEdit(event: FormEvent) {
     event.preventDefault();
     setEditTitle(false);
+    dispatch({
+      type: "newTitle",
+      payload: { ...props.column, title },
+    });
   }
 
   //experiment with delele

--- a/src/state/BoardContext.tsx
+++ b/src/state/BoardContext.tsx
@@ -42,12 +42,12 @@ export const initialState: State = isInLocalStorage
         "column-1": {
           id: "column-1",
           title: "To do",
-          taskIds: ["task-1", "task-2", "task-3", "task-4"],
+          taskIds: ["task-1", "task-2"],
         },
         "column-2": {
           id: "column-2",
           title: "In Progress",
-          taskIds: [],
+          taskIds: ["task-3", "task-4"],
         },
         "column-3": {
           id: "column-3",

--- a/src/state/reducer.tsx
+++ b/src/state/reducer.tsx
@@ -14,8 +14,6 @@ export default function reducer(state: State, action: Action) {
   switch (action.type) {
     case "addColumn": {
       let newIdNumber = state.columnOrder.length + 1;
-
-      console.log(usedIds);
       while (usedIds.includes(newIdNumber)) {
         newIdNumber = newIdNumber + 1;
       }
@@ -26,11 +24,6 @@ export default function reducer(state: State, action: Action) {
       const newColumns = { ...state.columns };
       newColumns[columnId] = { id: columnId, title: "Title", taskIds: [] };
 
-      console.log({
-        ...state,
-        columnOrder: newColumns,
-        columns: newColumnOrder,
-      });
       return { ...state, columnOrder: newColumnOrder, columns: newColumns };
     }
     case "deleteColumn": {
@@ -128,9 +121,19 @@ export default function reducer(state: State, action: Action) {
           newColumns[col] = { ...currentColumns[col] };
         }
       }
-      console.log(currentColumns);
-      console.log(newColumns);
-      // return state;
+      return { ...state, columns: newColumns };
+    }
+    case "newTitle": {
+      const { id } = action.payload;
+      const currentColumns = { ...state.columns };
+      const newColumns: Column = {};
+      for (let col in currentColumns) {
+        if (id === col) {
+          newColumns[col] = { ...action.payload };
+        } else {
+          newColumns[col] = currentColumns[col];
+        }
+      }
       return { ...state, columns: newColumns };
     }
     default: {


### PR DESCRIPTION
Update column title in the store. They are persisted after refresh and the titles show up correctly in the move menu.