### PR TITLE
Call setRefresh in reset board handler

### DIFF
--- a/src/components/Board.tsx
+++ b/src/components/Board.tsx
@@ -214,6 +214,7 @@ export default function Board() {
       handler: async () => {
         await localStorage.clear();
         dispatch({ type: "reset", payload: "" });
+        setRefresh(!refresh);
       },
     },
   ];


### PR DESCRIPTION
background image is now reliably reset to original image when resetting board